### PR TITLE
fix: preserve media router tabs added by other plugins

### DIFF
--- a/plugin-src/src/index.js
+++ b/plugin-src/src/index.js
@@ -611,24 +611,17 @@ registerBlockType('bynder/video-embed', {
 
 /**
  * Featured Image tab for Media Frame modal
+ *
+ * Preserve the inherited browseRouter (and any tabs added by other plugins, e.g.
+ * Cloudinary) by calling it first, then append the Bynder tab. Overwriting the
+ * method outright would drop tabs registered by other integrations.
  */
 var l10n = wp.media.view.l10n;
+var inheritedBrowseRouter =
+	wp.media.view.MediaFrame.Select.prototype.browseRouter;
 wp.media.view.MediaFrame.Select.prototype.browseRouter = function (routerView) {
-	if (wp.media.frame && wp.media.frame.options.state === 'featured-image') {
-		routerView.set({
-			upload: {
-				text: l10n.uploadFilesTitle,
-				priority: 20,
-			},
-			browse: {
-				text: l10n.mediaLibraryTitle,
-				priority: 40,
-			},
-			bynder: {
-				text: 'Bynder',
-				priority: 60,
-			},
-		});
+	if (typeof inheritedBrowseRouter === 'function') {
+		inheritedBrowseRouter.apply(this, arguments);
 	} else {
 		routerView.set({
 			upload: {
@@ -638,6 +631,15 @@ wp.media.view.MediaFrame.Select.prototype.browseRouter = function (routerView) {
 			browse: {
 				text: l10n.mediaLibraryTitle,
 				priority: 40,
+			},
+		});
+	}
+
+	if (wp.media.frame && wp.media.frame.options.state === 'featured-image') {
+		routerView.set({
+			bynder: {
+				text: 'Bynder',
+				priority: 60,
 			},
 		});
 	}


### PR DESCRIPTION
## Problem

The Featured Image media modal integration overrides `wp.media.view.MediaFrame.Select.prototype.browseRouter` and replaces it outright, setting only the `upload`, `browse` and `bynder` tabs.

Other plugins that integrate with the same media frame (for example the official **Cloudinary** plugin) also patch `browseRouter`, but they do so non-destructively by calling the inherited implementation first and then appending their own tab. Because Bynder replaces the method instead of extending it, whichever script loads last wins — and when Bynder loads after another integration, that plugin's tab (e.g. **Cloudinary**) disappears from the modal.

<img width="410" height="207" alt="before" src="https://github.com/user-attachments/assets/f78d413a-0e92-447a-ab72-48430efe70b5" />


## Fix

Capture the inherited `browseRouter` and call it first, then append the Bynder tab. This preserves any tabs registered by other plugins and makes the result independent of plugin load order. A fallback retains the original default tabs in case no inherited implementation exists.

<img width="543" height="166" alt="after" src="https://github.com/user-attachments/assets/178d6163-2e02-4018-8017-103d1b663a2d" />


## Testing

- With both Bynder and Cloudinary active, open the **Featured image** modal: Upload files, Media Library, Bynder and Cloudinary tabs are all present.
- With only Bynder active: behavior is unchanged (Upload files, Media Library, Bynder).

Note: only the source file `plugin-src/src/index.js` is changed; the build artifacts are generated at release time.